### PR TITLE
Extend the SendGridEvent model with a ContactId property

### DIFF
--- a/src/Models/SendGridEvent.cs
+++ b/src/Models/SendGridEvent.cs
@@ -33,6 +33,16 @@ namespace Kentico.Xperience.Twilio.SendGrid.Models
             set;
         }
 
+        /// <summary>
+        /// The Xperience newsletter contact ID.
+        /// </summary>
+        [JsonProperty(PropertyName = "X-CMS-ContactID")]
+        public string ContactId
+        {
+            get;
+            set;
+        }
+
 
         /// <summary>
         /// The email address of the recipient.


### PR DESCRIPTION
### Motivation

Extend the SendGridEvent model with the ContactId property which is present for mails sent from campaign email feeds. This will simplify the handling of bounce events for adding the bounce to the according contact.