### PR TITLE
Add contact ID to SendGridEvent

### DIFF
--- a/src/Kentico.Xperience.Twilio.SendGrid.csproj
+++ b/src/Kentico.Xperience.Twilio.SendGrid.csproj
@@ -8,7 +8,7 @@
 	<PropertyGroup>
 		<Title>Xperience SendGrid</Title>
 		<PackageId>Kentico.Xperience.Twilio.SendGrid</PackageId>
-		<Version>1.0.1</Version>
+		<Version>1.0.2</Version>
 		<Authors>Kentico Software</Authors>
 		<Company>Kentico Software</Company>
 		<PackageIcon>icon.png</PackageIcon>

--- a/src/Models/SendGridEvent.cs
+++ b/src/Models/SendGridEvent.cs
@@ -33,6 +33,16 @@ namespace Kentico.Xperience.Twilio.SendGrid.Models
             set;
         }
 
+        /// <summary>
+        /// The Xperience newsletter contact ID.
+        /// </summary>
+        [JsonProperty(PropertyName = "X-CMS-ContactID")]
+        public string ContactId
+        {
+            get;
+            set;
+        }
+
 
         /// <summary>
         /// The email address of the recipient.


### PR DESCRIPTION
### Motivation

Extend the SendGridEvent model with the ContactId property which is present for mails sent from campaign email feeds. This will simplify the handling of bounce events for adding the bounce to the according contact.

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Enable [event handling](https://github.com/Kentico/xperience-twilio-sendgrid#handling-sendgrid-event-webhooks), send Xperience newsletter, ensure `ContactId` is set when handing the SendGrid event
