### PR TITLE
fix issue #7 - Advanced export issues in the Suppressions page

### DIFF
--- a/CMS/CMSModules/Kentico.Xperience.Twilio.SendGrid/Pages/SuppressionManagement.aspx
+++ b/CMS/CMSModules/Kentico.Xperience.Twilio.SendGrid/Pages/SuppressionManagement.aspx
@@ -7,7 +7,7 @@
 <asp:Content ID="cntBody" runat="server" ContentPlaceHolderID="plcContent">
     <div class="cms-bootstrap" style="margin-top:10px">
         <cms:LocalizedHeading runat="server" Level="4" Text="Subscribed contacts" />
-        <cms:UniGrid ID="gridReport" runat="server" ShowExportMenu="true" EnableViewState="false" IsLiveSite="false"
+        <cms:UniGrid ID="gridReport" runat="server" ShowExportMenu="true" IsLiveSite="false"
             Columns="ContactID,ContactEmail,ContactBounces">
             <GridColumns>
                 <ug:Column runat="server" Source="ContactEmail" Caption="Email" Wrap="false">

--- a/src/Kentico.Xperience.Twilio.SendGrid.csproj
+++ b/src/Kentico.Xperience.Twilio.SendGrid.csproj
@@ -8,7 +8,7 @@
 	<PropertyGroup>
 		<Title>Xperience SendGrid</Title>
 		<PackageId>Kentico.Xperience.Twilio.SendGrid</PackageId>
-		<Version>1.0.1</Version>
+		<Version>1.0.2</Version>
 		<Authors>Kentico Software</Authors>
 		<Company>Kentico Software</Company>
 		<PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
the advanced export was always reloaded to default state, because view state was disabled on parent component, fixed by enabling the view state

### Motivation

Fixes #7 

### Deployment

The error is not in nuget package but in files imported to CMS.

Fix could be deployed by copying new version of CMS/CMSModules/Kentico.Xperience.Twilio.SendGrid/Pages/SuppressionManagement.aspx from the repository

